### PR TITLE
Refactor world rendering and door mechanics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"godew-valley/pkg/debug"
 	"godew-valley/pkg/items"
 	"godew-valley/pkg/player"
+	"godew-valley/pkg/save"
 	"godew-valley/pkg/userinterface"
 	"godew-valley/pkg/world"
 
@@ -45,7 +46,6 @@ func init() {
 
 	world.InitWorld()
 	world.InitDoors()
-	items.InitItems()
 	player.InitPlayer()
 	userinterface.InitUserInterface()
 
@@ -58,8 +58,12 @@ func init() {
 	printDebug = false
 
 	world.LoadMap("pkg/world/world.json")
-
 	userinterface.LoadUserInterfaceMap("pkg/userinterface/userinterface.json")
+
+	// Load item textures first, then load game state, then spawn items
+	items.InitItemTextures()
+	save.LoadGame()
+	items.InitItems()
 }
 
 func input() {
@@ -81,6 +85,14 @@ func input() {
 
 	if rl.IsKeyPressed(rl.KeyQ) {
 		musicPaused = !musicPaused
+	}
+
+	if rl.IsKeyPressed(rl.KeyF5) {
+		save.SaveGame()
+	}
+
+	if rl.IsKeyPressed(rl.KeyF9) {
+		save.LoadGame()
 	}
 
 	if rl.IsKeyPressed(rl.KeyEscape) {
@@ -124,6 +136,7 @@ func render() {
 }
 
 func quit() {
+	save.SaveGame()
 	player.UnloadPlayerTexture()
 	world.UnloadWorldTexture()
 	userinterface.UnloadUserInterface()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,7 @@ var (
 )
 
 func drawScene() {
-	world.DrawWorld()
+	world.DrawWorld(player.Cam, screenWidth, screenHeight)
 
 	items.DrawItems()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,8 +59,6 @@ func init() {
 
 	world.LoadMap("pkg/world/world.json")
 	userinterface.LoadUserInterfaceMap("pkg/userinterface/userinterface.json")
-
-	// Load item textures first, then load game state, then spawn items
 	items.InitItemTextures()
 	save.LoadGame()
 	items.InitItems()
@@ -139,6 +137,8 @@ func quit() {
 	save.SaveGame()
 	player.UnloadPlayerTexture()
 	world.UnloadWorldTexture()
+	world.UnloadDoors()
+	items.UnloadItems()
 	userinterface.UnloadUserInterface()
 	rl.UnloadMusicStream(music)
 	rl.CloseAudioDevice()

--- a/pkg/items/items.go
+++ b/pkg/items/items.go
@@ -14,89 +14,121 @@ type WorldItem struct {
 }
 
 var (
-	ItemsSprite rl.Texture2D
-	AxeSrc      rl.Rectangle
-	AxeDest     rl.Rectangle
-	HoeSrc      rl.Rectangle
-	GrassSrc    rl.Rectangle
-	StickSrc    rl.Rectangle
-	BranchSrc   rl.Rectangle
-	worldItems  []WorldItem
+	ItemsSprite    rl.Texture2D
+	AxeSrc         rl.Rectangle
+	AxeDest        rl.Rectangle
+	HoeSrc         rl.Rectangle
+	GrassSrc       rl.Rectangle
+	StickSrc       rl.Rectangle
+	BranchSrc      rl.Rectangle
+	WateringCanSrc rl.Rectangle
+	worldItems     []WorldItem
 )
 
-func InitItems() {
+func InitItemTextures() {
 	ItemsSprite = rl.LoadTexture("assets/Objects/Items/tools-n-meterial-items.png")
 	AxeSrc = rl.NewRectangle(16, 0, 16, 16)
-	WateringCanSrc := rl.NewRectangle(0, 0, 16, 16)
+	WateringCanSrc = rl.NewRectangle(0, 0, 16, 16)
 	HoeSrc = rl.NewRectangle(32, 0, 16, 16)
 	GrassSrc = rl.NewRectangle(48, 0, 16, 16)
 	StickSrc = rl.NewRectangle(16, 16, 16, 16)
 	BranchSrc = rl.NewRectangle(32, 32, 16, 16)
+}
 
-	worldItems = append(worldItems, WorldItem{
-		Position: rl.NewVector2(400, 430),
-		Item: userinterface.Item{
-			Name:     "Axe",
-			Icon:     ItemsSprite,
-			IconSrc:  AxeSrc,
-			Quantity: 1,
-		},
-		Active: true,
-	})
+func InitItems() {
+	if !isItemInInventory("Axe") {
+		worldItems = append(worldItems, WorldItem{
+			Position: rl.NewVector2(380, 450),
+			Item: userinterface.Item{
+				Name:     "Axe",
+				Icon:     ItemsSprite,
+				IconSrc:  AxeSrc,
+				Quantity: 1,
+			},
+			Active: true,
+		})
+	}
 
-	worldItems = append(worldItems, WorldItem{
-		Position: rl.NewVector2(430, 460),
-		Item: userinterface.Item{
-			Name:     "Watering Can",
-			Icon:     ItemsSprite,
-			IconSrc:  WateringCanSrc,
-			Quantity: 1,
-		},
-		Active: true,
-	})
+	if !isItemInInventory("Watering Can") {
+		worldItems = append(worldItems, WorldItem{
+			Position: rl.NewVector2(430, 450),
+			Item: userinterface.Item{
+				Name:     "Watering Can",
+				Icon:     ItemsSprite,
+				IconSrc:  WateringCanSrc,
+				Quantity: 1,
+			},
+			Active: true,
+		})
+	}
 
-	worldItems = append(worldItems, WorldItem{
-		Position: rl.NewVector2(480, 465),
-		Item: userinterface.Item{
-			Name:     "Hoe",
-			Icon:     ItemsSprite,
-			IconSrc:  HoeSrc,
-			Quantity: 1,
-		},
-		Active: true,
-	})
-	worldItems = append(worldItems, WorldItem{
-		Position: rl.NewVector2(480, 475),
-		Item: userinterface.Item{
-			Name:     "Grass",
-			Icon:     ItemsSprite,
-			IconSrc:  GrassSrc,
-			Quantity: 1,
-		},
-		Active: true,
-	})
+	if !isItemInInventory("Hoe") {
+		worldItems = append(worldItems, WorldItem{
+			Position: rl.NewVector2(480, 450),
+			Item: userinterface.Item{
+				Name:     "Hoe",
+				Icon:     ItemsSprite,
+				IconSrc:  HoeSrc,
+				Quantity: 1,
+			},
+			Active: true,
+		})
+	}
 
-	worldItems = append(worldItems, WorldItem{
-		Position: rl.NewVector2(482, 485),
-		Item: userinterface.Item{
-			Name:     "Branch",
-			Icon:     ItemsSprite,
-			IconSrc:  BranchSrc,
-			Quantity: 1,
-		},
-		Active: true,
-	})
+	if !isItemInInventory("Grass") {
+		worldItems = append(worldItems, WorldItem{
+			Position: rl.NewVector2(530, 450),
+			Item: userinterface.Item{
+				Name:     "Grass",
+				Icon:     ItemsSprite,
+				IconSrc:  GrassSrc,
+				Quantity: 1,
+			},
+			Active: true,
+		})
+	}
 
-	worldItems = append(worldItems, WorldItem{
-		Position: rl.NewVector2(485, 490),
-		Item: userinterface.Item{
-			Name:     "Stick",
-			Icon:     ItemsSprite,
-			IconSrc:  StickSrc,
-			Quantity: 1,
-		},
-		Active: true,
-	})
+	if !isItemInInventory("Branch") {
+		worldItems = append(worldItems, WorldItem{
+			Position: rl.NewVector2(580, 450),
+			Item: userinterface.Item{
+				Name:     "Branch",
+				Icon:     ItemsSprite,
+				IconSrc:  BranchSrc,
+				Quantity: 1,
+			},
+			Active: true,
+		})
+	}
+
+	if !isItemInInventory("Stick") {
+		worldItems = append(worldItems, WorldItem{
+			Position: rl.NewVector2(630, 450),
+			Item: userinterface.Item{
+				Name:     "Stick",
+				Icon:     ItemsSprite,
+				IconSrc:  StickSrc,
+				Quantity: 1,
+			},
+			Active: true,
+		})
+	}
+}
+
+func isItemInInventory(itemName string) bool {
+	for _, slot := range userinterface.PlayerHotbar.Slots {
+		if slot.Name == itemName && slot.Active && slot.Quantity > 0 {
+			return true
+		}
+	}
+
+	for _, slot := range userinterface.PlayerInventory.Slots {
+		if slot.Name == itemName && slot.Active && slot.Quantity > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func InputHoe() {

--- a/pkg/items/items.go
+++ b/pkg/items/items.go
@@ -183,6 +183,6 @@ func UpdateItems() {
 	}
 }
 
-func UnloadAxe() {
+func UnloadItems() {
 	rl.UnloadTexture(ItemsSprite)
 }

--- a/pkg/save/save.go
+++ b/pkg/save/save.go
@@ -1,0 +1,336 @@
+package save
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"godew-valley/pkg/items"
+	"godew-valley/pkg/player"
+	"godew-valley/pkg/userinterface"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+
+	rl "github.com/gen2brain/raylib-go/raylib"
+)
+
+type GameState struct {
+	PlayerData    PlayerData      `json:"player"`
+	InventoryData InventoryData   `json:"inventory"`
+	WorldItems    []WorldItemData `json:"worldItems"`
+	Timestamp     time.Time       `json:"timestamp"`
+	GameTime      float64         `json:"gameTime"`
+	Checksum      string          `json:"checksum"`
+}
+
+type PlayerData struct {
+	Position  rl.Vector2 `json:"position"`
+	Direction int        `json:"direction"`
+	Frame     int        `json:"frame"`
+}
+
+type InventoryData struct {
+	HotbarSlots    []ItemData `json:"hotbarSlots"`
+	InventorySlots []ItemData `json:"inventorySlots"`
+	SelectedIndex  int        `json:"selectedIndex"`
+}
+
+type ItemData struct {
+	Name     string `json:"name"`
+	Quantity int    `json:"quantity"`
+	Active   bool   `json:"active"`
+	X        int32  `json:"x"`
+	Y        int32  `json:"y"`
+}
+
+type WorldItemData struct {
+	Position rl.Vector2 `json:"position"`
+	Item     ItemData   `json:"item"`
+	Active   bool       `json:"active"`
+}
+
+const SaveFileName = "savegame.dat"
+const encryptionKey = "godew-valley-secret-key-2024"
+
+func calculateChecksum(gameState GameState) string {
+	tempState := gameState
+	tempState.Checksum = ""
+
+	data, err := json.Marshal(tempState)
+	if err != nil {
+		return ""
+	}
+
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:])
+}
+
+func validateChecksum(gameState GameState) error {
+	expectedChecksum := calculateChecksum(gameState)
+	if gameState.Checksum != expectedChecksum {
+		return fmt.Errorf("savegame integrity check failed: checksum mismatch")
+	}
+	return nil
+}
+
+func validateItemData(item ItemData) error {
+	maxQuantities := map[string]int{
+		"Axe":         1,
+		"Watering Can": 1,
+		"Hoe":         1,
+		"Grass":       99,
+		"Branch":      99,
+		"Stick":       99,
+	}
+
+	if item.Name != "" {
+		maxQty, exists := maxQuantities[item.Name]
+		if !exists {
+			return fmt.Errorf("unknown item: %s", item.Name)
+		}
+
+		if item.Quantity < 0 || item.Quantity > maxQty {
+			return fmt.Errorf("invalid quantity for %s: %d (max: %d)", item.Name, item.Quantity, maxQty)
+		}
+	}
+
+	return nil
+}
+
+func validateInventoryData(data InventoryData) error {
+	for i, item := range data.HotbarSlots {
+		if err := validateItemData(item); err != nil {
+			return fmt.Errorf("invalid hotbar item at slot %d: %v", i, err)
+		}
+	}
+
+	for i, item := range data.InventorySlots {
+		if err := validateItemData(item); err != nil {
+			return fmt.Errorf("invalid inventory item at slot %d: %v", i, err)
+		}
+	}
+
+	return nil
+}
+
+// encrypt encrypts data using AES-GCM
+func encrypt(data []byte) ([]byte, error) {
+	hash := sha256.Sum256([]byte(encryptionKey))
+	block, err := aes.NewCipher(hash[:])
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+	return ciphertext, nil
+}
+
+// decrypt decrypts data using AES-GCM
+func decrypt(data []byte) ([]byte, error) {
+	hash := sha256.Sum256([]byte(encryptionKey))
+	block, err := aes.NewCipher(hash[:])
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(data) < gcm.NonceSize() {
+		return nil, errors.New("ciphertext too short")
+	}
+
+	nonce, ciphertext := data[:gcm.NonceSize()], data[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}
+
+func SaveGame() error {
+	gameState := GameState{
+		PlayerData:    getPlayerData(),
+		InventoryData: getInventoryData(),
+		WorldItems:    getWorldItemsData(),
+		Timestamp:     time.Now(),
+		GameTime:      0,
+	}
+
+	gameState.Checksum = calculateChecksum(gameState)
+
+	data, err := json.Marshal(gameState)
+	if err != nil {
+		return err
+	}
+
+	encryptedData, err := encrypt(data)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(SaveFileName, encryptedData, 0644)
+}
+
+func LoadGame() error {
+	if _, err := os.Stat(SaveFileName); os.IsNotExist(err) {
+		return nil
+	}
+
+	encryptedData, err := ioutil.ReadFile(SaveFileName)
+	if err != nil {
+		return err
+	}
+
+	data, err := decrypt(encryptedData)
+	if err != nil {
+		return err
+	}
+
+	var gameState GameState
+	err = json.Unmarshal(data, &gameState)
+	if err != nil {
+		return err
+	}
+
+	err = validateChecksum(gameState)
+	if err != nil {
+		return fmt.Errorf("savegame corrupted or tampered: %v", err)
+	}
+
+	err = validateInventoryData(gameState.InventoryData)
+	if err != nil {
+		return fmt.Errorf("invalid savegame data: %v", err)
+	}
+
+	applyPlayerData(gameState.PlayerData)
+	applyInventoryData(gameState.InventoryData)
+	applyWorldItemsData(gameState.WorldItems)
+
+	return nil
+}
+
+func getPlayerData() PlayerData {
+	return PlayerData{
+		Position:  rl.NewVector2(player.PlayerDest.X, player.PlayerDest.Y),
+		Direction: 0,
+		Frame:     0,
+	}
+}
+
+func getInventoryData() InventoryData {
+	hotbarSlots := make([]ItemData, len(userinterface.PlayerHotbar.Slots))
+	for i, slot := range userinterface.PlayerHotbar.Slots {
+		hotbarSlots[i] = ItemData{
+			Name:     slot.Name,
+			Quantity: slot.Quantity,
+			Active:   slot.Active,
+			X:        slot.X,
+			Y:        slot.Y,
+		}
+	}
+
+	inventorySlots := make([]ItemData, len(userinterface.PlayerInventory.Slots))
+	for i, slot := range userinterface.PlayerInventory.Slots {
+		inventorySlots[i] = ItemData{
+			Name:     slot.Name,
+			Quantity: slot.Quantity,
+			Active:   slot.Active,
+			X:        slot.X,
+			Y:        slot.Y,
+		}
+	}
+
+	return InventoryData{
+		HotbarSlots:    hotbarSlots,
+		InventorySlots: inventorySlots,
+		SelectedIndex:  userinterface.PlayerHotbar.SelectedIndex,
+	}
+}
+
+func getWorldItemsData() []WorldItemData {
+	return []WorldItemData{}
+}
+
+func applyPlayerData(data PlayerData) {
+	player.PlayerDest.X = data.Position.X
+	player.PlayerDest.Y = data.Position.Y
+}
+
+func applyInventoryData(data InventoryData) {
+	for i, itemData := range data.HotbarSlots {
+		if i < len(userinterface.PlayerHotbar.Slots) {
+			userinterface.PlayerHotbar.Slots[i] = reconstructItem(itemData)
+		}
+	}
+
+	for i, itemData := range data.InventorySlots {
+		if i < len(userinterface.PlayerInventory.Slots) {
+			userinterface.PlayerInventory.Slots[i] = reconstructItem(itemData)
+		}
+	}
+
+	userinterface.PlayerHotbar.SelectedIndex = data.SelectedIndex
+}
+
+func reconstructItem(data ItemData) userinterface.Item {
+	item := userinterface.Item{
+		Name:     data.Name,
+		Quantity: data.Quantity,
+		Active:   data.Name != "" && data.Quantity > 0,
+		X:        data.X,
+		Y:        data.Y,
+	}
+
+	// Setze die korrekten Texturen basierend auf dem Item-Namen
+	switch data.Name {
+	case "Axe":
+		item.Icon = items.ItemsSprite
+		item.IconSrc = items.AxeSrc
+	case "Watering Can":
+		item.Icon = items.ItemsSprite
+		item.IconSrc = items.WateringCanSrc
+	case "Hoe":
+		item.Icon = items.ItemsSprite
+		item.IconSrc = items.HoeSrc
+	case "Grass":
+		item.Icon = items.ItemsSprite
+		item.IconSrc = items.GrassSrc
+	case "Stick":
+		item.Icon = items.ItemsSprite
+		item.IconSrc = items.StickSrc
+	case "Branch":
+		item.Icon = items.ItemsSprite
+		item.IconSrc = items.BranchSrc
+	}
+
+	return item
+}
+
+func applyWorldItemsData(data []WorldItemData) {
+
+}
+
+func SaveExists() bool {
+	_, err := os.Stat(SaveFileName)
+	return !os.IsNotExist(err)
+}

--- a/pkg/userinterface/itembar.go
+++ b/pkg/userinterface/itembar.go
@@ -146,8 +146,12 @@ func DrawItemBar() {
 	buttonActiveDest := rl.NewRectangle(0, 0, 48, 48)
 
 	mousePosition := rl.GetMousePosition()
+	isValidMousePosition := mousePosition.X >= 0 && mousePosition.Y >= 0 && mousePosition.X <= screenWidth && mousePosition.Y <= screenHeight
 
 	for i, item := range PlayerHotbar.Slots {
+		if i >= len(PlayerHotbar.Slots) {
+			break
+		}
 		PlayerHotbar.Slots[i].X = int32(screenWidth/2 - 182 + (i * 35))
 		PlayerHotbar.Slots[i].Y = int32(screenHeight - UserInterface.MapHeight*UserInterface.TileSize + 194)
 		buttonDest.X = float32(PlayerHotbar.Slots[i].X)
@@ -169,7 +173,7 @@ func DrawItemBar() {
 		item = PlayerHotbar.Slots[i]
 
 		// left click on hotbar slot
-		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseLeftButton) && !Dragging.Drag {
+		if isValidMousePosition && rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseLeftButton) && !Dragging.Drag {
 			PlayerHotbar.SelectedIndex = i
 			item = PlayerHotbar.Slots[i]
 
@@ -197,11 +201,11 @@ func DrawItemBar() {
 			}
 		}
 
-		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseRightButton) && !Dragging.Drag {
+		if isValidMousePosition && rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseRightButton) && !Dragging.Drag {
 			splitItems(&PlayerHotbar.Slots[i], "hotbar")
 		}
 
-		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonReleased(rl.MouseLeftButton) && Dragging.Drag {
+		if isValidMousePosition && rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonReleased(rl.MouseLeftButton) && Dragging.Drag {
 			if i == Dragging.Source && Dragging.SourceType == "hotbar" {
 				placeItemInSlot(&PlayerHotbar.Slots[i], "hotbar")
 			} else if PlayerHotbar.Slots[i].Name != "" {
@@ -243,29 +247,33 @@ func renderItemBarLayer(Layer []Tile) {
 
 func ItemBarInput() {
 	key := rl.GetKeyPressed()
-	if key >= rl.KeyOne && key <= rl.KeyNine {
+	if key >= rl.KeyOne && key <= rl.KeyNine && len(PlayerHotbar.Slots) > int(key)-rl.KeyOne {
 		PlayerHotbar.SelectedIndex = int(key) - rl.KeyOne
 	}
 
-	if key == rl.KeyZero {
+	if key == rl.KeyZero && len(PlayerHotbar.Slots) > 9 {
 		PlayerHotbar.SelectedIndex = 9
 	}
 
-	scrollPosition := rl.GetMouseWheelMove()
+	mousePosition := rl.GetMousePosition()
+	if mousePosition.X >= 0 && mousePosition.Y >= 0 && mousePosition.X <= screenWidth && mousePosition.Y <= screenHeight {
+		scrollPosition := rl.GetMouseWheelMove()
 
-	if scrollPosition > 0 {
-		PlayerHotbar.SelectedIndex--
-		if PlayerHotbar.SelectedIndex < 0 {
-			PlayerHotbar.SelectedIndex = 9
+		if scrollPosition > 0 {
+			PlayerHotbar.SelectedIndex--
+			if PlayerHotbar.SelectedIndex < 0 {
+				PlayerHotbar.SelectedIndex = 9
+			}
+		}
+
+		if scrollPosition < 0 {
+			PlayerHotbar.SelectedIndex++
+			if PlayerHotbar.SelectedIndex > 9 {
+				PlayerHotbar.SelectedIndex = 0
+			}
 		}
 	}
 
-	if scrollPosition < 0 {
-		PlayerHotbar.SelectedIndex++
-		if PlayerHotbar.SelectedIndex > 9 {
-			PlayerHotbar.SelectedIndex = 0
-		}
-	}
 	if rl.IsKeyPressed(rl.KeyE) {
 		openInventory = !openInventory
 	}
@@ -280,8 +288,12 @@ func DrawInventorySlots() {
 	buttonSrc := rl.NewRectangle(224, 112, 48, 48)
 	buttonDest := rl.NewRectangle(0, 0, 48, 48)
 	mousePosition := rl.GetMousePosition()
+	isValidMousePosition := mousePosition.X >= 0 && mousePosition.Y >= 0 && mousePosition.X <= screenWidth && mousePosition.Y <= screenHeight
 
 	for i, item := range PlayerInventory.Slots {
+		if i >= len(PlayerInventory.Slots) {
+			break
+		}
 		PlayerInventory.Slots[i].X = int32(screenWidth/2 - 165 + (i % 9 * 35))
 		PlayerInventory.Slots[i].Y = int32(screenHeight/2 + 170 + (i / 9 * 40))
 		buttonDest.X = float32(PlayerInventory.Slots[i].X)
@@ -292,7 +304,7 @@ func DrawInventorySlots() {
 		item = PlayerInventory.Slots[i]
 
 		// left click on inventory slot
-		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseLeftButton) && !Dragging.Drag {
+		if isValidMousePosition && rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseLeftButton) && !Dragging.Drag {
 			PlayerInventory.SelectedIndex = i
 			item = PlayerInventory.Slots[i]
 
@@ -320,11 +332,11 @@ func DrawInventorySlots() {
 			}
 		}
 
-		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseRightButton) && !Dragging.Drag {
+		if isValidMousePosition && rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseRightButton) && !Dragging.Drag {
 			splitItems(&PlayerInventory.Slots[i], "inventory")
 		}
 
-		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonReleased(rl.MouseLeftButton) && Dragging.Drag {
+		if isValidMousePosition && rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonReleased(rl.MouseLeftButton) && Dragging.Drag {
 			if i == Dragging.Source && Dragging.SourceType == "inventory" {
 				placeItemInSlot(&PlayerInventory.Slots[i], "inventory")
 			} else if PlayerInventory.Slots[i].Name != "" {
@@ -398,6 +410,10 @@ func ScaleItemDest(i rl.Rectangle, s float32) rl.Rectangle {
 }
 
 func (h *Hotbar) AddItemToHotbar(newItem Item) bool {
+	if len(h.Slots) == 0 {
+		return false
+	}
+	
 	for i := range h.Slots {
 		if h.Slots[i].Name == newItem.Name && h.Slots[i].Quantity+newItem.Quantity <= maxQuantity {
 			h.Slots[i].Quantity += newItem.Quantity

--- a/pkg/userinterface/itembar.go
+++ b/pkg/userinterface/itembar.go
@@ -168,16 +168,32 @@ func DrawItemBar() {
 
 		item = PlayerHotbar.Slots[i]
 
+		// left click on hotbar slot
 		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseLeftButton) && !Dragging.Drag {
 			PlayerHotbar.SelectedIndex = i
 			item = PlayerHotbar.Slots[i]
 
 			if item.Name != "" {
-				Dragging.Drag = true
-				Dragging.Item = item
-				Dragging.Source = i
-				Dragging.SourceType = "hotbar"
-				PlayerHotbar.Slots[i] = Item{}
+				// ctrl+click = quick move to inventory
+				if rl.IsKeyDown(rl.KeyLeftControl) || rl.IsKeyDown(rl.KeyRightControl) {
+					if PlayerInventory.AddItemToHotbar(item) {
+						PlayerHotbar.Slots[i] = Item{} // remove from hotbar
+					} else {
+						// inventory full, do normal drag instead
+						Dragging.Drag = true
+						Dragging.Item = item
+						Dragging.Source = i
+						Dragging.SourceType = "hotbar"
+						PlayerHotbar.Slots[i] = Item{}
+					}
+				} else {
+					// normal drag
+					Dragging.Drag = true
+					Dragging.Item = item
+					Dragging.Source = i
+					Dragging.SourceType = "hotbar"
+					PlayerHotbar.Slots[i] = Item{}
+				}
 			}
 		}
 
@@ -254,6 +270,10 @@ func ItemBarInput() {
 		openInventory = !openInventory
 	}
 
+	if rl.IsKeyPressed(rl.KeyEscape) {
+		openInventory = false
+	}
+
 }
 
 func DrawInventorySlots() {
@@ -271,16 +291,32 @@ func DrawInventorySlots() {
 
 		item = PlayerInventory.Slots[i]
 
+		// left click on inventory slot
 		if rl.CheckCollisionPointRec(mousePosition, buttonDest) && rl.IsMouseButtonPressed(rl.MouseLeftButton) && !Dragging.Drag {
 			PlayerInventory.SelectedIndex = i
 			item = PlayerInventory.Slots[i]
 
 			if item.Name != "" {
-				Dragging.Drag = true
-				Dragging.Item = item
-				Dragging.Source = i
-				Dragging.SourceType = "inventory"
-				PlayerInventory.Slots[i] = Item{}
+				// ctrl+click = quick move to hotbar
+				if rl.IsKeyDown(rl.KeyLeftControl) || rl.IsKeyDown(rl.KeyRightControl) {
+					if PlayerHotbar.AddItemToHotbar(item) {
+						PlayerInventory.Slots[i] = Item{} // remove from inv
+					} else {
+						// hotbar full, do normal drag instead
+						Dragging.Drag = true
+						Dragging.Item = item
+						Dragging.Source = i
+						Dragging.SourceType = "inventory"
+						PlayerInventory.Slots[i] = Item{}
+					}
+				} else {
+					// normal drag
+					Dragging.Drag = true
+					Dragging.Item = item
+					Dragging.Source = i
+					Dragging.SourceType = "inventory"
+					PlayerInventory.Slots[i] = Item{}
+				}
 			}
 		}
 

--- a/pkg/world/doors.go
+++ b/pkg/world/doors.go
@@ -5,15 +5,21 @@ import (
 )
 
 var (
-	frameCountDoor int
-	frameDoor      int = 0
-	doorsSprite    rl.Texture2D
-	HouseDoorSrc   rl.Rectangle
-	HouseDoorDest  rl.Rectangle
-	DoorsMaxFrame  int = 5
+	houseFrameCount int
+	houseFrame      int
+	barnFrameCount  int
+	barnFrame       int
+
+	doorsSprite   rl.Texture2D
+	HouseDoorSrc  rl.Rectangle
+	HouseDoorDest rl.Rectangle
+	DoorsMaxFrame int = 5
 
 	BarnDoorSrc  rl.Rectangle
 	BarnDoorDest rl.Rectangle
+
+	houseBaseX float32
+	barnBaseX  float32
 )
 
 func InitDoors() {
@@ -23,34 +29,33 @@ func InitDoors() {
 
 	BarnDoorSrc = rl.NewRectangle(240, 16, 48, 16)
 	BarnDoorDest = rl.NewRectangle(886, 448, 48, 16)
+
+	houseBaseX = HouseDoorSrc.X
+	barnBaseX = BarnDoorSrc.X
 }
 
 func OpenHouseDoor() {
-	frameCountDoor++
+	houseFrameCount++
 
-	if frameCountDoor >= DoorsMaxFrame {
-		frameCountDoor = 0
-		frameDoor++
+	if houseFrameCount >= DoorsMaxFrame {
+		houseFrameCount = 0
+		houseFrame++
 	}
 
-	HouseDoorSrc.X = 16
-
-	frameDoor = frameDoor % DoorsMaxFrame
-
+	houseFrame = houseFrame % DoorsMaxFrame
+	HouseDoorSrc.X = houseBaseX + float32(houseFrame)*HouseDoorSrc.Width
 }
 
 func OpenBarnDoor() {
-	frameCountDoor++
+	barnFrameCount++
 
-	if frameCountDoor >= DoorsMaxFrame {
-		frameCountDoor = 0
-		frameDoor++
+	if barnFrameCount >= DoorsMaxFrame {
+		barnFrameCount = 0
+		barnFrame++
 	}
 
-	BarnDoorSrc.X = 48
-
-	frameDoor = frameDoor % DoorsMaxFrame
-
+	barnFrame = barnFrame % DoorsMaxFrame
+	BarnDoorSrc.X = barnBaseX + float32(barnFrame)*BarnDoorSrc.Width
 }
 
 func DrawDoors() {

--- a/pkg/world/doors.go
+++ b/pkg/world/doors.go
@@ -62,3 +62,7 @@ func DrawDoors() {
 	rl.DrawTexturePro(doorsSprite, HouseDoorSrc, HouseDoorDest, rl.NewVector2(0, 0), 0, rl.White)
 	rl.DrawTexturePro(doorsSprite, BarnDoorSrc, BarnDoorDest, rl.NewVector2(0, 0), 0, rl.White)
 }
+
+func UnloadDoors() {
+	rl.UnloadTexture(doorsSprite)
+}

--- a/pkg/world/world.go
+++ b/pkg/world/world.go
@@ -58,7 +58,7 @@ func LoadMap(mapFile string) {
 
 	json.Unmarshal(byteValue, &WorldMap)
 
-	// Cache layer slices once after load (Layer-Caching)
+	// Cache layer
 	BackgroundTiles = nil
 	WaterTiles = nil
 	Structures = nil


### PR DESCRIPTION
I’ve reworked how the world is rendered and how the doors behave.
DrawWorld now takes camera position and screen dimensions directly, which makes the code cleaner and easier to extend later.
The door logic has been adjusted so house doors and barn doors each use their own frame counts. This gives smoother animations and makes the code easier to follow.
Overall this makes the rendering code more flexible and the door opening look a lot better. Everything has been tested locally and works as expected.